### PR TITLE
fix: ajustar urlpatterns em reviews/urls e include em speedgarage/urls

### DIFF
--- a/reviews/urls.py
+++ b/reviews/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+from .views import CarroViewSet, CriticaViewSet
+
+router = DefaultRouter()
+router.register(r'cars',    CarroViewSet,   basename='carro')
+router.register(r'reviews', CriticaViewSet, basename='critica')
+
+urlpatterns = router.urls

--- a/speedgarage/urls.py
+++ b/speedgarage/urls.py
@@ -1,31 +1,10 @@
-"""
-URL configuration for speedgarage project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
-    # Rota do tal do ADM
     path('admin/', admin.site.urls),
-
-    # include das rotas da app reviews
     path('api/', include('reviews.urls')),
-
-    # Endpoints JWT
-    path('api/token/',  TokenObtainPairView.as_view(), name='token_obtain'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/token/',        TokenObtainPairView.as_view(),   name='token_obtain'),
+    path('api/token/refresh/',TokenRefreshView.as_view(),     name='token_refresh'),
 ]


### PR DESCRIPTION
• Garante que reviews/urls.py exporte `urlpatterns = router.urls`  
• Assegura que speedgarage/urls.py faça `include('reviews.urls')`  
• Corrige o erro “does not appear to have any patterns” no deploy
