### PR TITLE
fix(ordering+serializer): \

### DIFF
--- a/reviews/serializers.py
+++ b/reviews/serializers.py
@@ -18,9 +18,14 @@ class CriticaSerializer(serializers.ModelSerializer):
     class Meta:
         model  = Critica
         # Apenas os campos básicos: carro, avaliacao, texto, criado_em
-        fields = ["id", "usuario_nome","carro_nome", "avaliacao", "texto", "criado_em"]
+        fields = ["id", "carro",  # ← novo
+                 "usuario_nome", "carro_nome",
+                 "avaliacao", "texto", "criado_em"]
         read_only_fields = ["usuario", "criado_em"]
-        
+        extra_kwargs = {
+            "carro": {"write_only": True}
+        }
+
     def get_usuario_nome(self, obj):
         return obj.usuario.username  
 
@@ -56,7 +61,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         username_or_email = attrs.get('username')
         password = attrs.get('password')
 
-        # Sua lógica para permitir login com email (que está ótima)
+        # lógica para permitir login com email (que está ótima)
         if '@' in username_or_email:
             try:
                 # Encontra o usuário pelo email
@@ -67,7 +72,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
                 # Se não encontrar, a validação padrão abaixo irá falhar, o que é o esperado
                 pass
         
-        # 1. Chama o método original para obter os tokens
+        # 1. Chama o metodo original para obter os tokens
         # Ele autentica o usuário e retorna {'access': '...', 'refresh': '...'}
         data = super().validate(attrs)
         

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -19,7 +19,9 @@ class CarroViewSet(viewsets.ModelViewSet):
     queryset = Carro.objects.all()
     serializer_class = CarroSerializer
     permission_classes = [permissions.IsAuthenticated]          # exige login
-    filter_backends = [filters.SearchFilter]
+    filter_backends = [filters.OrderingFilter, filters.SearchFilter]
+    ordering_fields = ["marca", "modelo", "ano"]  # ← campos permitidos
+    ordering = ["-ano"]
     search_fields = ["marca", "modelo", "ano"]
 
 
@@ -27,7 +29,9 @@ class CriticaViewSet(viewsets.ModelViewSet):
     queryset = Critica.objects.select_related("carro", "usuario")
     serializer_class = CriticaSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-    filter_backends = [filters.SearchFilter]
+    filter_backends = [filters.OrderingFilter, filters.SearchFilter]
+    ordering_fields = ["avaliacao", "criado_em", "carro__ano"]
+    ordering = ["-criado_em"]
     search_fields = ["carro__marca", "carro__modelo", "texto"]
 
     # NEW ➜ passa o request para o serializer


### PR DESCRIPTION
Inclui campo 'carro' em CriticaSerializer e ordena Carro por ano desc

CriticaSerializer – campo carro adicionado como write-only (corrige IntegrityError nos testes)

CarroViewSet – ordering = ["-ano"], testes de ordenação passam

Todos os 12 testes verdes, com muitos warnings (pytest -q).